### PR TITLE
bump: Country select to match with half_signup gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "decidim", DECIDIM_VERSION
 gem "decidim-extra_user_fields", path: "."
 
 gem "bootsnap", "~> 1.4"
-gem "country_select", "~> 4.0"
+gem "country_select", "~> 9.0"
 gem "puma", ">= 4.3"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     decidim-extra_user_fields (0.27.2)
-      country_select (~> 4.0)
+      country_select (~> 9.0)
       decidim-core (>= 0.27.0, < 0.28)
       deface (~> 1.5)
 
@@ -146,13 +146,10 @@ GEM
     coffee-script-source (1.12.2)
     commonmarker (0.23.10)
     concurrent-ruby (1.2.2)
-    countries (3.1.0)
-      i18n_data (~> 0.11.0)
-      sixarm_ruby_unaccent (~> 1.1)
-      unicode_utils (~> 1.4)
-    country_select (4.0.0)
-      countries (~> 3.0)
-      sort_alphabetical (~> 1.0)
+    countries (6.0.0)
+      unaccent (~> 0.3)
+    country_select (9.0.0)
+      countries (> 5.0, < 7.0)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -443,7 +440,6 @@ GEM
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
-    i18n_data (0.11.0)
     icalendar (2.9.0)
       ice_cube (~> 0.16)
     ice_cube (0.16.4)
@@ -734,15 +730,12 @@ GEM
       simplecov (~> 0.19)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    sixarm_ruby_unaccent (1.2.2)
     smart_properties (1.17.0)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
     social-share-button (1.2.4)
       coffee-rails
-    sort_alphabetical (1.1.0)
-      unicode_utils (>= 1.2.2)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -766,8 +759,8 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
+    unaccent (0.4.0)
     unicode-display_width (2.4.2)
-    unicode_utils (1.4.0)
     valid_email2 (2.3.1)
       activemodel (>= 3.2)
       mail (~> 2.5)
@@ -825,7 +818,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (~> 1.4)
   byebug (~> 11.0)
-  country_select (~> 4.0)
+  country_select (~> 9.0)
   decidim (~> 0.27.4)
   decidim-dev (~> 0.27.4)
   decidim-extra_user_fields!

--- a/decidim-extra_user_fields.gemspec
+++ b/decidim-extra_user_fields.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*", "LICENSE-AGPLv3.txt", "Rakefile", "README.md"]
 
-  s.add_dependency "country_select", "~> 4.0"
+  s.add_dependency "country_select", "~> 9.0"
   s.add_dependency "decidim-core", Decidim::ExtraUserFields.decidim_version
   s.add_dependency "deface", "~> 1.5"
 end


### PR DESCRIPTION
### 🎩 Description

This bump is necessary to manage compatibility between half sign_up and extra user fields but we need to make sure it doesn't break anything and that this major bump is absolutely necessary.

```
    decidim-extra_user_fields was resolved to 0.27.2, which depends on
      country_select (~> 4.0) was resolved to 4.0.0, which depends on
        countries (~> 3.0)

    decidim-half_signup was resolved to 0.27.0, which depends on
      countries (~> 5.1, >= 5.1.2)
```