### PR TITLE
Fix export of participants

### DIFF
--- a/app/controllers/decidim/extra_user_fields/admin/extra_user_fields_controller.rb
+++ b/app/controllers/decidim/extra_user_fields/admin/extra_user_fields_controller.rb
@@ -37,17 +37,13 @@ module Decidim
 
         def export_users
           enforce_permission_to :read, :officialization
+
           Decidim.traceability.perform_action!("export_users", current_organization, current_user, { format: params[:format] }) do
             ExportParticipantsJob.perform_later(current_organization, current_user, params[:format])
           end
 
           flash[:notice] = t("decidim.admin.exports.notice")
           redirect_to engine_routes.officializations_path
-          #ExportUsers.call(params[:format], current_user) do
-          #  on(:ok) do |export_data|
-          #     send_data export_data.read, type: "text/#{export_data.extension}", filename: export_data.filename("participants")
-          #  end
-          #end
         end
 
         private

--- a/app/controllers/decidim/extra_user_fields/admin/extra_user_fields_controller.rb
+++ b/app/controllers/decidim/extra_user_fields/admin/extra_user_fields_controller.rb
@@ -37,12 +37,21 @@ module Decidim
 
         def export_users
           enforce_permission_to :read, :officialization
+          ExportParticipantsJob.perform_later(current_organization, current_user, params[:format])
 
-          ExportUsers.call(params[:format], current_user) do
-            on(:ok) do |export_data|
-              send_data export_data.read, type: "text/#{export_data.extension}", filename: export_data.filename("participants")
-            end
-          end
+          flash[:notice] = t("decidim.admin.exports.notice")
+          redirect_to engine_routes.officializations_path
+          #ExportUsers.call(params[:format], current_user) do
+          #  on(:ok) do |export_data|
+          #     send_data export_data.read, type: "text/#{export_data.extension}", filename: export_data.filename("participants")
+          #  end
+          #end
+        end
+
+        private
+
+        def engine_routes
+          Decidim::Admin::Engine.routes.url_helpers
         end
       end
     end

--- a/app/controllers/decidim/extra_user_fields/admin/extra_user_fields_controller.rb
+++ b/app/controllers/decidim/extra_user_fields/admin/extra_user_fields_controller.rb
@@ -37,7 +37,9 @@ module Decidim
 
         def export_users
           enforce_permission_to :read, :officialization
-          ExportParticipantsJob.perform_later(current_organization, current_user, params[:format])
+          Decidim.traceability.perform_action!("export_users", current_organization, current_user, { format: params[:format] }) do
+            ExportParticipantsJob.perform_later(current_organization, current_user, params[:format])
+          end
 
           flash[:notice] = t("decidim.admin.exports.notice")
           redirect_to engine_routes.officializations_path

--- a/app/jobs/decidim/extra_user_fields/admin/export_participants_job.rb
+++ b/app/jobs/decidim/extra_user_fields/admin/export_participants_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal = true
+
+module Decidim
+  module ExtraUserFields
+    module Admin
+      class ExportParticipantsJob < ApplicationJob
+        queue_as :exports
+
+        def perform(organization, user, format)
+          collection = organization.users.not_deleted
+          export_data = Decidim::Exporters.find_exporter(format).new(collection, Decidim::ExtraUserFields::UserExportSerializer).export
+          ExportMailer.export(user, "participants", export_data).deliver_now
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/decidim/extra_user_fields/admin/export_participants_job_spec.rb
+++ b/spec/jobs/decidim/extra_user_fields/admin/export_participants_job_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module ExtraUserFields
+    module Admin
+      describe ExportParticipantsJob, type: :job do
+        let(:organization) { create(:organization, extra_user_fields: {}) }
+        let(:user) { create :user, :admin, :confirmed, organization: organization }
+        let(:format) { "CSV" }
+
+        it "sends an email with a file attached" do
+          ExportParticipantsJob.perform_now(organization, user, format)
+          email = last_email
+          expect(email.subject).to include("participants")
+          attachment = email.attachments.first
+
+          expect(attachment.read.length).to be_positive
+          expect(attachment.mime_type).to eq("application/zip")
+          expect(attachment.filename).to match(/^participants-[0-9]+-[0-9]+-[0-9]+-[0-9]+\.zip$/)
+        end
+
+        context "when format is CSV" do
+          it "uses the csv exporter" do
+            export_data = double
+            expect(Decidim::Exporters::CSV).to(receive(:new).with(anything, Decidim::ExtraUserFields::UserExportSerializer)).and_return(double(export: export_data))
+            expect(ExportMailer)
+              .to(receive(:export).with(user, "participants", export_data))
+              .and_return(double(deliver_now: true))
+            ExportParticipantsJob.perform_now(organization, user, format)
+          end
+        end
+
+        context "when format is JSON" do
+          let(:format) { "JSON" }
+
+          it "uses the json exporter" do
+            export_data = double
+            expect(Decidim::Exporters::JSON)
+              .to(receive(:new).with(anything, Decidim::ExtraUserFields::UserExportSerializer))
+              .and_return(double(export: export_data))
+            expect(ExportMailer)
+              .to(receive(:export).with(user, "participants", export_data))
+              .and_return(double(deliver_now: true))
+            ExportParticipantsJob.perform_now(organization, user, format)
+          end
+        end
+
+        context "when format is excel" do
+          let(:format) { "Excel" }
+
+          it "uses the excel exporter" do
+            export_data = double
+            expect(Decidim::Exporters::Excel)
+              .to(receive(:new).with(anything, Decidim::ExtraUserFields::UserExportSerializer))
+              .and_return(double(export: export_data))
+            expect(ExportMailer)
+              .to(receive(:export).with(user, "participants", export_data))
+              .and_return(double(deliver_now: true))
+            ExportParticipantsJob.perform_now(organization, user, format)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/system/admin_manages_officializations_spec.rb
+++ b/spec/system/admin_manages_officializations_spec.rb
@@ -24,4 +24,16 @@ describe "Admin manages officializations", type: :system do
 
     expect(page).to have_content("Export")
   end
+
+  context "when clicking on export csv button" do
+    it "redirects to officialization index page and display a flash message" do
+      click_link "Participants"
+      find(".button--title").click
+      find(".exports--format--csv").click
+
+      expect(page).to have_title("Participants")
+      expect(page).to have_content("Export")
+      expect(page).to have_content("Your export is currently in progress. You'll receive an email when it's complete.")
+    end
+  end
 end


### PR DESCRIPTION
🎩 Description

To avoid timeout with large files, modify the export of participants to be handled by an asynchronous job and send the file by email to the current user.

📌 Related Issues

Notion card https://www.notion.so/opensourcepolitics/bd4bf860eab94f9daca7da803f09e3b2?v=c96df65755dd403d95e86f82d7749709&p=96caa6882dac455191c3f29338ec6364&pm=c

Testing

1. As an admin, go to "Participants" and click on "Participants"  (cf screenshot)
2. Click on Export button, click on the chosen type of file
3. See that you get a message  "Your export is currently in progress. You'll receive an email when it's complete."
4. Go to letter_opener and check that you received an email with the file attached as zip
5. Upload the zip and see in the generated file that you have the list of participants

Tasks
[ X] Add specs

Screenshot

<img width="1497" alt="Capture d’écran 2024-06-25 à 11 58 15" src="https://github.com/OpenSourcePolitics/decidim-module-extra_user_fields/assets/61418966/14084b0f-505f-4618-9e72-b6057cf50d74">

